### PR TITLE
Fix abort when scanning for  complex graph

### DIFF
--- a/internal/ccall/common/routespl.c
+++ b/internal/ccall/common/routespl.c
@@ -353,8 +353,8 @@ limitBoxes (boxf* boxes, int boxn, pointf *pps, int pn, int delta)
 	    for (bi = 0; bi < boxn; bi++) {
 /* this tested ok on 64bit machines, but on 32bit we need this FUDGE
  *     or graphs/directed/records.gv fails */
-#define FUDGE .0001
-		if (sp[0].y <= boxes[bi].UR.y+FUDGE && sp[0].y >= boxes[bi].LL.y-FUDGE) {
+#define ROUTESPL_FUDGE .0001
+		if (sp[0].y <= boxes[bi].UR.y+ROUTESPL_FUDGE && sp[0].y >= boxes[bi].LL.y-ROUTESPL_FUDGE) {
 		    if (boxes[bi].LL.x > sp[0].x)
 			boxes[bi].LL.x = sp[0].x;
 		    if (boxes[bi].UR.x < sp[0].x)
@@ -1045,3 +1045,5 @@ makeStraightEdges(graph_t * g, edge_t** edges, int e_cnt, int et, splineInfo* si
 	dumb[2].y += del.y;
     }
 }
+
+#undef ROUTESPL_FUDGE

--- a/internal/ccall/common/splines.c
+++ b/internal/ccall/common/splines.c
@@ -386,10 +386,7 @@ void add_box(path * P, boxf b)
  * too close the side of the node.
  *
  */
-#ifndef FUDGE
-#define FUDGE 2
-#endif
-
+#define SPLINES_FUDGE 2
 #define HT2(n) (ND_ht(n)/2)
 
 void
@@ -433,7 +430,7 @@ beginpath(path * P, edge_t * e, int et, pathend_t * endp, boolean merge)
 		b0.LL.y = P->start.p.y;
 		b0.UR.x = b.UR.x;
 		b0.UR.y = ND_coord(n).y + HT2(n) + GD_ranksep(agraphof(n))/2;
-		b.UR.x = ND_coord(n).x - ND_lw(n) - (FUDGE-2);
+		b.UR.x = ND_coord(n).x - ND_lw(n) - (SPLINES_FUDGE-2);
 		b.UR.y = b0.LL.y;
 		b.LL.y = ND_coord(n).y - HT2(n);
 		b.LL.x -= 1;
@@ -446,7 +443,7 @@ beginpath(path * P, edge_t * e, int et, pathend_t * endp, boolean merge)
 		/* b0.LL.y = ND_coord(n).y + HT2(n); */
 		b0.UR.x = b.UR.x+1;
 		b0.UR.y = ND_coord(n).y + HT2(n) + GD_ranksep(agraphof(n))/2;
-		b.LL.x = ND_coord(n).x + ND_rw(n) + (FUDGE-2);
+		b.LL.x = ND_coord(n).x + ND_rw(n) + (SPLINES_FUDGE-2);
 		b.UR.y = b0.LL.y;
 		b.LL.y = ND_coord(n).y - HT2(n);
 		b.UR.x += 1;
@@ -503,7 +500,7 @@ beginpath(path * P, edge_t * e, int et, pathend_t * endp, boolean merge)
 		b0.UR.x = b.UR.x+1;
 		b0.LL.x = P->start.p.x;
 		b0.LL.y = b0.UR.y - GD_ranksep(agraphof(n))/2;
-		b.LL.x = ND_coord(n).x + ND_rw(n) + (FUDGE-2);
+		b.LL.x = ND_coord(n).x + ND_rw(n) + (SPLINES_FUDGE-2);
 		b.LL.y = b0.UR.y;
 		b.UR.y = ND_coord(n).y + HT2(n);
 		b.UR.x += 1;
@@ -634,7 +631,7 @@ void endpath(path * P, edge_t * e, int et, pathend_t * endp, boolean merge)
 		b0.UR.y = P->end.p.y;
 		b0.UR.x = b.UR.x;
 		b0.LL.y = ND_coord(n).y - HT2(n) - GD_ranksep(agraphof(n))/2;
-		b.UR.x = ND_coord(n).x - ND_lw(n) - (FUDGE-2);
+		b.UR.x = ND_coord(n).x - ND_lw(n) - (SPLINES_FUDGE-2);
 		b.LL.y = b0.UR.y;
 		b.UR.y = ND_coord(n).y + HT2(n);
 		b.LL.x -= 1;
@@ -647,7 +644,7 @@ void endpath(path * P, edge_t * e, int et, pathend_t * endp, boolean merge)
 		/* b0.UR.y = ND_coord(n).y - HT2(n); */
 		b0.UR.x = b.UR.x+1;
 		b0.LL.y = ND_coord(n).y - HT2(n) - GD_ranksep(agraphof(n))/2;
-		b.LL.x = ND_coord(n).x + ND_rw(n) + (FUDGE-2);
+		b.LL.x = ND_coord(n).x + ND_rw(n) + (SPLINES_FUDGE-2);
 		b.LL.y = b0.UR.y;
 		b.UR.y = ND_coord(n).y + HT2(n);
 		b.UR.x += 1;
@@ -1491,3 +1488,4 @@ splines *getsplinepoints(edge_t * e)
     return sp;
 }
 
+#undef SPLINES_FUDGE

--- a/internal/ccall/dotgen/dotsplines.c
+++ b/internal/ccall/dotgen/dotsplines.c
@@ -2416,7 +2416,7 @@ static Agraph_t *cl_bound(graph_t* g,  node_t *n, node_t *adj)
  * FUDGE-2 away from the node, so the routing can avoid the node and the
  * box is at least 2 wide.
  */
-#define FUDGE 4
+#define DOTSPLINES_FUDGE 4
 
 static boxf maximal_bbox(graph_t* g, spline_info_t* sp, node_t* vn, edge_t* ie, edge_t* oe)
 {
@@ -2428,7 +2428,7 @@ static boxf maximal_bbox(graph_t* g, spline_info_t* sp, node_t* vn, edge_t* ie, 
     left_cl = right_cl = NULL;
 
     /* give this node all the available space up to its neighbors */
-    b = (double)(ND_coord(vn).x - ND_lw(vn) - FUDGE);
+    b = (double)(ND_coord(vn).x - ND_lw(vn) - DOTSPLINES_FUDGE);
     if ((left = _neighbor(g, vn, ie, oe, -1))) {
 	if ((left_cl = cl_bound(g, vn, left)))
 	    nb = GD_bb(left_cl).UR.x + (double)(sp->Splinesep);
@@ -2449,7 +2449,7 @@ static boxf maximal_bbox(graph_t* g, spline_info_t* sp, node_t* vn, edge_t* ie, 
     if ((ND_node_type(vn) == VIRTUAL) && (ND_label(vn)))
 	b = (double)(ND_coord(vn).x + 10);
     else
-	b = (double)(ND_coord(vn).x + ND_rw(vn) + FUDGE);
+	b = (double)(ND_coord(vn).x + ND_rw(vn) + DOTSPLINES_FUDGE);
     if ((right = _neighbor(g, vn, ie, oe, 1))) {
 	if ((right_cl = cl_bound(g, vn, right)))
 	    nb = GD_bb(right_cl).LL.x - (double)(sp->Splinesep);
@@ -2564,3 +2564,5 @@ void showpath(path * p)
     fprintf(stderr, "showpage\n");
 }
 #endif
+
+#undef DOTSPLINES_FUDGE

--- a/internal/ccall/pathplan/route.c
+++ b/internal/ccall/pathplan/route.c
@@ -69,8 +69,8 @@ static int p2en;
 static elist_t *elist;
 #endif
 
-static Ppoint_t *ops;
-static int opn, opl;
+static Ppoint_t *route_ops;
+static int route_opn, route_opl;
 
 static int reallyroutespline(Pedge_t *, int,
 			     Ppoint_t *, int, Ppoint_t, Ppoint_t);
@@ -85,7 +85,7 @@ static void addroot(double, double *, int *);
 
 static Pvector_t normv(Pvector_t);
 
-static void _growops(int);
+static void _growroute_ops(int);
 
 static Ppoint_t add(Ppoint_t, Ppoint_t);
 static Ppoint_t sub(Ppoint_t, Ppoint_t);
@@ -119,7 +119,7 @@ int Proutespline(Pedge_t * edges, int edgen, Ppolyline_t input,
     Ppoint_t p0, p1, p2, p3;
     Ppoint_t *pp;
     Pvector_t v1, v2, v12, v23;
-    int ipi, opi;
+    int ipi, route_opi;
     int ei, p2ei;
     Pedge_t *e0p, *e1p;
 #endif
@@ -174,22 +174,22 @@ int Proutespline(Pedge_t * edges, int edgen, Ppolyline_t input,
     /* generate the splines */
     evs[0] = normv(evs[0]);
     evs[1] = normv(evs[1]);
-    opl = 0;
-    _growops(4);
-    ops[opl++] = inps[0];
+    route_opl = 0;
+    _growroute_ops(4);
+    route_ops[route_opl++] = inps[0];
     if (reallyroutespline(edges, edgen, inps, inpn, evs[0], evs[1]) == -1)
 	return -1;
-    output->pn = opl;
-    output->ps = ops;
+    output->pn = route_opl;
+    output->ps = route_ops;
 
 #if 0
     fprintf(stderr, "edge\na\nb\n");
     fprintf(stderr, "points\n%d\n", inpn);
     for (ipi = 0; ipi < inpn; ipi++)
 	fprintf(stderr, "%f %f\n", inps[ipi].x, inps[ipi].y);
-    fprintf(stderr, "splpoints\n%d\n", opl);
-    for (opi = 0; opi < opl; opi++)
-	fprintf(stderr, "%f %f\n", ops[opi].x, ops[opi].y);
+    fprintf(stderr, "splpoints\n%d\n", route_opl);
+    for (route_opi = 0; route_opi < route_opl; route_opi++)
+	fprintf(stderr, "%f %f\n", route_ops[route_opi].x, route_ops[route_opi].y);
 #endif
 
     return 0;
@@ -349,9 +349,9 @@ static int splinefits(Pedge_t * edges, int edgen, Ppoint_t pa,
 	first = 0;
 
 	if (splineisinside(edges, edgen, &sps[0])) {
-      _growops(opl + 4);
+      _growroute_ops(route_opl + 4);
 	    for (pi = 1; pi < 4; pi++)
-		ops[opl].x = sps[pi].x, ops[opl++].y = sps[pi].y;
+		route_ops[route_opl].x = sps[pi].x, route_ops[route_opl++].y = sps[pi].y;
 #if defined(DEBUG) && DEBUG >= 1
 	    fprintf(stderr, "success: %f %f\n", a, b);
 #endif
@@ -359,9 +359,9 @@ static int splinefits(Pedge_t * edges, int edgen, Ppoint_t pa,
 	}
 	if (a == 0 && b == 0) {
 	    if (forceflag) {
-          _growops(opl + 4);
+          _growroute_ops(route_opl + 4);
 		for (pi = 1; pi < 4; pi++)
-		    ops[opl].x = sps[pi].x, ops[opl++].y = sps[pi].y;
+		    route_ops[route_opl].x = sps[pi].x, route_ops[route_opl++].y = sps[pi].y;
 #if defined(DEBUG) && DEBUG >= 1
 		fprintf(stderr, "forced straight line: %f %f\n", a, b);
 #endif
@@ -522,23 +522,23 @@ static Pvector_t normv(Pvector_t v)
     return v;
 }
 
-static void _growops(int newopn)
+static void _growroute_ops(int newroute_opn)
 {
-    if (newopn <= opn)
+    if (newroute_opn <= route_opn)
 	return;
-    if (!ops) {
-	if (!(ops = (Ppoint_t *) malloc(POINTSIZE * newopn))) {
-	    prerror("cannot malloc ops");
+    if (!route_ops) {
+	if (!(route_ops = (Ppoint_t *) malloc(POINTSIZE * newroute_opn))) {
+	    prerror("cannot malloc route_ops");
 	    longjmp(jbuf,1);
 	}
     } else {
-	if (!(ops = (Ppoint_t *) realloc((void *) ops,
-					 POINTSIZE * newopn))) {
-	    prerror("cannot realloc ops");
+	if (!(route_ops = (Ppoint_t *) realloc((void *) route_ops,
+					 POINTSIZE * newroute_opn))) {
+	    prerror("cannot realloc route_ops");
 	    longjmp(jbuf,1);
 	}
     }
-    opn = newopn;
+    route_opn = newroute_opn;
 }
 
 static Ppoint_t add(Ppoint_t p1, Ppoint_t p2)


### PR DESCRIPTION
`ops` , `on` variable names are conflicted .
Therefore, it had undefined behavior .

## MEMO

Enable statically build by the following
```
CFLAGS="-O0 -g" ./configure --enable-static
```

And debugging the following on macOS

```
lldb -- ./cmd/dot/dot_static -Tpng -osample.png graphs/directed/abstract.gv
```

Also, cgo's debugging is

```
CGO_CFLAGS="-O0 -g" go build cmd/dot/dot.go
gdb --args ./dot -Tpng -o sample.png abstract.gv
```
