### PR TITLE
Fix the issue that the order of subgraph does not idempotent

### DIFF
--- a/internal/ccall/cgraph/graph.c
+++ b/internal/ccall/cgraph/graph.c
@@ -77,7 +77,7 @@ Agraph_t *agopen1(Agraph_t * g)
     g->n_id = agdtopen(g, &Ag_subnode_id_disc, Dttree);
     g->e_seq = agdtopen(g, g == agroot(g)? &Ag_mainedge_seq_disc : &Ag_subedge_seq_disc, Dttree);
     g->e_id = agdtopen(g, g == agroot(g)? &Ag_mainedge_id_disc : &Ag_subedge_id_disc, Dttree);
-    g->g_dict = agdtopen(g, &Ag_subgraph_id_disc, Dttree);
+    g->g_dict = agdtopen(g, &Ag_subgraph_id_disc, Dtlist);
 
     par = agparent(g);
     if (par) {


### PR DESCRIPTION
Thank you for sharing the reproduction code and some information @k1LoW !
Maybe, I resolved this issue :)

## Issue

The order of subgraph does not idempotent .
Because it use `dttree` for searching subgraph ( `ordered set` ) .
It depends on keys of dictionary but keys are not sorted .

Probably, Graphviz also have same problem ( FYI: https://gitlab.com/graphviz/graphviz/-/issues/1614 )

### Reproduction code 

```go
package main

import (
	"bytes"
	"fmt"
	"io"

	"github.com/goccy/go-graphviz"
	"github.com/google/go-cmp/cmp"
)

const dot = `digraph test {
  graph [layout=dot];
  subgraph "cluster_a" {
    "node_1";
  }
  subgraph "cluster_b" {
    "node_2";
  }
}
`

func main() {
	diffc := 0
	nodiffc := 0
	for i := 0; i < 30; i++ {
		g := &Gviz{}
		buf := []byte(dot)
		a := &bytes.Buffer{}
		b := &bytes.Buffer{}
		if err := g.render(a, buf); err != nil {
			panic(err)
		}
		if err := g.render(b, buf); err != nil {
			panic(err)
		}

		if diff := cmp.Diff(a.Bytes(), b.Bytes(), nil); diff != "" {
			diffc++
			continue
		}
		nodiffc++
	}
	fmt.Printf("diff exist:%d / no diff:%d\n", diffc, nodiffc)
}

type Gviz struct {
}

func (g *Gviz) render(wr io.Writer, b []byte) (e error) {
	format := "svg"
	gviz := graphviz.New()
	graph, err := graphviz.ParseBytes(b)
	if err != nil {
		return err
	}
	defer func() {
		if err := gviz.Close(); err != nil {
			e = err
		}
		if err := graph.Close(); err != nil {
			e = err
		}
	}()
	if err := gviz.Render(graph, graphviz.Format(format), wr); err != nil {
		return err
	}
	return nil
}
```

## Solution

Therefor, I fix this issue by using linked list for searching subgraph ( `Dtlist` )
