### PR TITLE
fix: go mod vendor

### DIFF
--- a/internal/ccall/ast/dummy.go
+++ b/internal/ccall/ast/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/build_cgo_hack.go
+++ b/internal/ccall/build_cgo_hack.go
@@ -1,0 +1,69 @@
+// +build required
+
+package ccall
+
+// This file exists purely to prevent the golang toolchain from stripping
+// away the c source directories and files when `go mod vendor` is used
+// to populate a `vendor/` directory of a project depending on `goccy/go-graphviz`.
+//
+// How it works:
+//  - every directory which only includes c source files receives a dummy.go file.
+//  - every directory we want to preserve is included here as a _ import.
+//  - this file is given a build to exclude it from the regular build.
+import (
+	// Prevent go tooling from stripping out the c source files.
+	_ "github.com/goccy/go-graphviz/internal"
+	_ "github.com/goccy/go-graphviz/internal/ccall/ast"
+	_ "github.com/goccy/go-graphviz/internal/ccall/cdt"
+	_ "github.com/goccy/go-graphviz/internal/ccall/cgraph"
+	_ "github.com/goccy/go-graphviz/internal/ccall/circogen"
+	_ "github.com/goccy/go-graphviz/internal/ccall/common"
+	_ "github.com/goccy/go-graphviz/internal/ccall/dotgen"
+	_ "github.com/goccy/go-graphviz/internal/ccall/edgepaint"
+	_ "github.com/goccy/go-graphviz/internal/ccall/expr"
+	_ "github.com/goccy/go-graphviz/internal/ccall/fdpgen"
+	_ "github.com/goccy/go-graphviz/internal/ccall/glcomp"
+	_ "github.com/goccy/go-graphviz/internal/ccall/gvc"
+	_ "github.com/goccy/go-graphviz/internal/ccall/gvpr"
+	_ "github.com/goccy/go-graphviz/internal/ccall/ingraphs"
+	_ "github.com/goccy/go-graphviz/internal/ccall/label"
+	_ "github.com/goccy/go-graphviz/internal/ccall/mingle"
+	_ "github.com/goccy/go-graphviz/internal/ccall/neatogen"
+	_ "github.com/goccy/go-graphviz/internal/ccall/ortho"
+	_ "github.com/goccy/go-graphviz/internal/ccall/osage"
+	_ "github.com/goccy/go-graphviz/internal/ccall/pack"
+	_ "github.com/goccy/go-graphviz/internal/ccall/patchwork"
+	_ "github.com/goccy/go-graphviz/internal/ccall/pathplan"
+	_ "github.com/goccy/go-graphviz/internal/ccall/rbtree"
+	_ "github.com/goccy/go-graphviz/internal/ccall/sfdpgen"
+	_ "github.com/goccy/go-graphviz/internal/ccall/sfio"
+	_ "github.com/goccy/go-graphviz/internal/ccall/sfio/Sfio_f"
+	_ "github.com/goccy/go-graphviz/internal/ccall/sparse"
+	_ "github.com/goccy/go-graphviz/internal/ccall/spine"
+	_ "github.com/goccy/go-graphviz/internal/ccall/topfish"
+	_ "github.com/goccy/go-graphviz/internal/ccall/twopigen"
+	_ "github.com/goccy/go-graphviz/internal/ccall/vmalloc"
+	_ "github.com/goccy/go-graphviz/internal/ccall/vpsc"
+	_ "github.com/goccy/go-graphviz/internal/ccall/vpsc/pairingheap"
+	_ "github.com/goccy/go-graphviz/internal/ccall/xdot"
+	_ "github.com/goccy/go-graphviz/internal/expat"
+	_ "github.com/goccy/go-graphviz/internal/plugin/core"
+	_ "github.com/goccy/go-graphviz/internal/plugin/devil"
+	_ "github.com/goccy/go-graphviz/internal/plugin/dot_layout"
+	_ "github.com/goccy/go-graphviz/internal/plugin/gd"
+	_ "github.com/goccy/go-graphviz/internal/plugin/gdiplus"
+	_ "github.com/goccy/go-graphviz/internal/plugin/gdk"
+	_ "github.com/goccy/go-graphviz/internal/plugin/glitz"
+	_ "github.com/goccy/go-graphviz/internal/plugin/gs"
+	_ "github.com/goccy/go-graphviz/internal/plugin/gtk"
+	_ "github.com/goccy/go-graphviz/internal/plugin/lasi"
+	_ "github.com/goccy/go-graphviz/internal/plugin/ming"
+	_ "github.com/goccy/go-graphviz/internal/plugin/neato_layout"
+	_ "github.com/goccy/go-graphviz/internal/plugin/pango"
+	_ "github.com/goccy/go-graphviz/internal/plugin/poppler"
+	_ "github.com/goccy/go-graphviz/internal/plugin/quartz"
+	_ "github.com/goccy/go-graphviz/internal/plugin/rsvg"
+	_ "github.com/goccy/go-graphviz/internal/plugin/visio"
+	_ "github.com/goccy/go-graphviz/internal/plugin/webp"
+	_ "github.com/goccy/go-graphviz/internal/plugin/xlib"
+)

--- a/internal/ccall/cdt/dummy.go
+++ b/internal/ccall/cdt/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/cgraph/dummy.go
+++ b/internal/ccall/cgraph/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/circogen/dummy.go
+++ b/internal/ccall/circogen/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/common/dummy.go
+++ b/internal/ccall/common/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/dotgen/dummy.go
+++ b/internal/ccall/dotgen/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/edgepaint/dummy.go
+++ b/internal/ccall/edgepaint/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/expr/dummy.go
+++ b/internal/ccall/expr/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/fdpgen/dummy.go
+++ b/internal/ccall/fdpgen/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/glcomp/dummy.go
+++ b/internal/ccall/glcomp/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/gvc/dummy.go
+++ b/internal/ccall/gvc/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/gvpr/dummy.go
+++ b/internal/ccall/gvpr/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/ingraphs/dummy.go
+++ b/internal/ccall/ingraphs/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/label/dummy.go
+++ b/internal/ccall/label/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/mingle/dummy.go
+++ b/internal/ccall/mingle/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/neatogen/dummy.go
+++ b/internal/ccall/neatogen/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/ortho/dummy.go
+++ b/internal/ccall/ortho/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/osage/dummy.go
+++ b/internal/ccall/osage/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/pack/dummy.go
+++ b/internal/ccall/pack/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/patchwork/dummy.go
+++ b/internal/ccall/patchwork/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/pathplan/dummy.go
+++ b/internal/ccall/pathplan/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/rbtree/dummy.go
+++ b/internal/ccall/rbtree/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/sfdpgen/dummy.go
+++ b/internal/ccall/sfdpgen/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/sfio/Sfio_f/dummy.go
+++ b/internal/ccall/sfio/Sfio_f/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/sfio/dummy.go
+++ b/internal/ccall/sfio/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/sparse/dummy.go
+++ b/internal/ccall/sparse/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/spine/dummy.go
+++ b/internal/ccall/spine/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/topfish/dummy.go
+++ b/internal/ccall/topfish/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/twopigen/dummy.go
+++ b/internal/ccall/twopigen/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/vmalloc/dummy.go
+++ b/internal/ccall/vmalloc/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/vpsc/dummy.go
+++ b/internal/ccall/vpsc/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/vpsc/pairingheap/dummy.go
+++ b/internal/ccall/vpsc/pairingheap/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/ccall/xdot/dummy.go
+++ b/internal/ccall/xdot/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/dummy.go
+++ b/internal/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/expat/dummy.go
+++ b/internal/expat/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/core/dummy.go
+++ b/internal/plugin/core/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/devil/dummy.go
+++ b/internal/plugin/devil/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/dot_layout/dummy.go
+++ b/internal/plugin/dot_layout/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/gd/dummy.go
+++ b/internal/plugin/gd/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/gdiplus/dummy.go
+++ b/internal/plugin/gdiplus/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/gdk/dummy.go
+++ b/internal/plugin/gdk/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/glitz/dummy.go
+++ b/internal/plugin/glitz/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/gs/dummy.go
+++ b/internal/plugin/gs/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/gtk/dummy.go
+++ b/internal/plugin/gtk/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/lasi/dummy.go
+++ b/internal/plugin/lasi/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/ming/dummy.go
+++ b/internal/plugin/ming/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/neato_layout/dummy.go
+++ b/internal/plugin/neato_layout/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/pango/dummy.go
+++ b/internal/plugin/pango/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/poppler/dummy.go
+++ b/internal/plugin/poppler/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/quartz/dummy.go
+++ b/internal/plugin/quartz/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/rsvg/dummy.go
+++ b/internal/plugin/rsvg/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/visio/dummy.go
+++ b/internal/plugin/visio/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/webp/dummy.go
+++ b/internal/plugin/webp/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy

--- a/internal/plugin/xlib/dummy.go
+++ b/internal/plugin/xlib/dummy.go
@@ -1,0 +1,4 @@
+// +build required
+
+// Package dummy prevents go tooling from stripping the c dependencies.
+package dummy


### PR DESCRIPTION
Closes #28 

Uses https://github.com/go-gl/glfw/pull/280 as a guide to enable this project to be vendored into other projects with `go mod vendor`