### PR TITLE
Fix Windows compilation errors

### DIFF
--- a/internal/ccall/cdt.go
+++ b/internal/ccall/cdt.go
@@ -2,6 +2,7 @@ package ccall
 
 /*
 #cgo CFLAGS: -DGVLIBDIR=graphviz
+#cgo CFLAGS: -fcommon
 #cgo CFLAGS: -Icdt
 #cgo CFLAGS: -Icommon
 #cgo CFLAGS: -Igvc


### PR DESCRIPTION
This addresses a problem where, when compiling on Windows, yields numerous errors like the following:

```
/usr/lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld: /tmp/go-link-3876510343/000027.o:/go-graphviz/internal/ccall/cdt/cdt.h:169: multiple definition of `Dtset'; /tmp/go-link-3876510343/000000.o:/go-graphviz/internal/ccall/cdt/cdt.h:169: first defined here
```

The reason for these errors is because the header files are violating the [one definition rule](https://en.wikipedia.org/wiki/One_Definition_Rule): a given thing may be declared in many places, but must be defined in one place only. If you've seen much C/C++ code, you know this rule is frequently broken, as is the case here, and the GNU CC even provides the `-fcommon` option to avoid situations exactly like this.

This PR adds a comment to `cdt.go` that adds the `-fcommon` option, causing GNU compilers to ignore multiple definitions. This is necessary for wrapping C code that puts definitions in header files, and ultimately makes the code into a single, cohesive package. Thinking of the underlying issue like a truth table:

|  | add the comment | fix the C code |
| -- | -- | -- |
| definitions in header files | 1 | 0 |
| only declarations in header files | 0 | 1 |

You'll see that we currently have zero of the two viable options; this PR implements the only solution that preserves the C source code that is imported into this project.

As a side note, this fixes #38 