### PR TITLE
Added higher-level API for querying a node's degree in a graph

### DIFF
--- a/cgraph/cgraph.go
+++ b/cgraph/cgraph.go
@@ -1151,7 +1151,7 @@ func (g *Graph) Outdegree(n *Node) int {
 }
 
 // Returns the total degree of the given node in the graph.
-// This can be though of as the total number of edges coming
+// This can be thought of as the total number of edges coming
 // in and out of a node.
 func (g *Graph) TotalDegree(n *Node) int {
 	return ccall.Agdegree(g.Agraph, n.Agnode, 1, 1)

--- a/cgraph/cgraph.go
+++ b/cgraph/cgraph.go
@@ -1117,8 +1117,44 @@ func (g *Graph) NumberSubGraph() int {
 	return ccall.Agnsubg(g.Agraph)
 }
 
+// Returns the degree of the given node in the graph, where arguments "in" and
+// "out" are C-like booleans that select which edge sets to query.
+//
+//	g.Degree(node, 0, 0) // always returns 0
+//	g.Degree(node, 0, 1) // returns the node's outdegree
+//	g.Degree(node, 1, 0) // returns the node's indegree
+//	g.Degree(node, 1, 1) // returns the node's total degree (indegree + outdegree)
 func (g *Graph) Degree(n *Node, in, out int) int {
 	return ccall.Agdegree(g.Agraph, n.Agnode, in, out)
+}
+
+// Returns the indegree of the given node in the graph.
+//
+// Note: While undirected graphs don't normally have a
+// notion of indegrees, calling this method on an
+// undirected graph will treat it as if it's directed.
+// As a result, it's best to avoid calling this method
+// on an undirected graph.
+func (g *Graph) Indegree(n *Node) int {
+	return ccall.Agdegree(g.Agraph, n.Agnode, 1, 0)
+}
+
+// Returns the outdegree of the given node in the graph.
+//
+// Note: While undirected graphs don't normally have a
+// notion of outdegrees, calling this method on an
+// undirected graph will treat it as if it's directed.
+// As a result, it's best to avoid calling this method
+// on an undirected graph.
+func (g *Graph) Outdegree(n *Node) int {
+	return ccall.Agdegree(g.Agraph, n.Agnode, 0, 1)
+}
+
+// Returns the total degree of the given node in the graph.
+// This can be though of as the total number of edges coming
+// in and out of a node.
+func (g *Graph) TotalDegree(n *Node) int {
+	return ccall.Agdegree(g.Agraph, n.Agnode, 1, 1)
 }
 
 func (g *Graph) CountUniqueEdges(n *Node, in, out int) int {

--- a/graphviz_test.go
+++ b/graphviz_test.go
@@ -149,3 +149,68 @@ func TestParseFile(t *testing.T) {
 		}
 	}
 }
+
+func TestNodeDegree(t *testing.T) {
+	type test struct {
+		node_name             string
+		expected_indegree     int
+		expected_outdegree    int
+		expected_total_degree int
+	}
+
+	type graphtest struct {
+		input string
+		tests []test
+	}
+
+	graphtests := []graphtest{
+		{input: "digraph test { a -> b }", tests: []test{
+			{node_name: "a", expected_indegree: 0, expected_outdegree: 1, expected_total_degree: 1},
+			{node_name: "b", expected_indegree: 1, expected_outdegree: 0, expected_total_degree: 1},
+		}},
+		{input: "digraph test { a -> b; a -> b; a -> a; c -> a }", tests: []test{
+			{node_name: "a", expected_indegree: 2, expected_outdegree: 3, expected_total_degree: 5},
+			{node_name: "b", expected_indegree: 2, expected_outdegree: 0, expected_total_degree: 2},
+			{node_name: "c", expected_indegree: 0, expected_outdegree: 1, expected_total_degree: 1},
+		}},
+		{input: "graph test { a -- b; a -- b; a -- a; c -- a }", tests: []test{
+			{node_name: "a", expected_indegree: 2, expected_outdegree: 3, expected_total_degree: 5},
+			{node_name: "b", expected_indegree: 2, expected_outdegree: 0, expected_total_degree: 2},
+			{node_name: "c", expected_indegree: 0, expected_outdegree: 1, expected_total_degree: 1},
+		}},
+		{input: "strict graph test { a -- b; b -- a; a -- a; c -- a }", tests: []test{
+			{node_name: "a", expected_indegree: 2, expected_outdegree: 2, expected_total_degree: 4},
+			{node_name: "b", expected_indegree: 1, expected_outdegree: 0, expected_total_degree: 1},
+			{node_name: "c", expected_indegree: 0, expected_outdegree: 1, expected_total_degree: 1},
+		}},
+	}
+
+	for _, graphtest := range graphtests {
+		input := graphtest.input
+		graph, err := graphviz.ParseBytes([]byte(input))
+		if err != nil {
+			t.Fatalf("Input: %s. Error: %+v", input, err)
+		}
+
+		for _, test := range graphtest.tests {
+			node_name := test.node_name
+			node, err := graph.Node(node_name)
+			if err != nil || node == nil {
+				t.Fatalf("Unable to retrieve node '%s'. Input: %s. Error: %+v", node_name, input, err)
+			}
+
+			indegree := graph.Indegree(node)
+			if test.expected_indegree != indegree {
+				t.Errorf("Unexpected indegree for node '%s'. Input: %s. Expected: %d. Actual: %d.", node_name, input, test.expected_indegree, indegree)
+			}
+			outdegree := graph.Outdegree(node)
+			if test.expected_outdegree != outdegree {
+				t.Errorf("Unexpected outdegree for node '%s'. Input: %s. Expected: %d. Actual: %d.", node_name, input, test.expected_outdegree, outdegree)
+			}
+			total_degree := graph.TotalDegree(node)
+			if test.expected_total_degree != total_degree {
+				t.Errorf("Unexpected total degree for node '%s'. Input: %s. Expected: %d. Actual: %d.", node_name, input, test.expected_total_degree, total_degree)
+			}
+		}
+	}
+}


### PR DESCRIPTION
As pointed out in #74, the current method for getting a node's degree in a graph ([`Degree(n *Node, in, out int)`](https://github.com/goccy/go-graphviz/blob/865af036ddbb745c4424bbd2fdaa9a75668cf0d4/cgraph/cgraph.go#L1120)) is unergonomic for most use cases and unnecessarily mimics its C counterpart. 

This PR introduces higher-level API methods (`Indegree(n *Node)`, `Outdegree(n *Node)`, and `TotalDegree(n *Node)`)** that simplify retrieving a node's indegree, outdegree, or sum of both. It also adds documentation to the relevant methods to communicate better how they should be used.

_** I'm open to changing these names if they're unclear or don't follow the naming convention._