### PR TITLE
Update params to make new clang happy

### DIFF
--- a/internal/ccall/dotgen/dotsplines.c
+++ b/internal/ccall/dotgen/dotsplines.c
@@ -2307,9 +2307,7 @@ static void recover_slack(edge_t * e, path * p)
     }
 }
 
-static void resize_vn(vn, lx, cx, rx)
-node_t *vn;
-int lx, cx, rx;
+static void resize_vn(node_t * vn, int lx, int cx, int rx)
 {
     ND_coord(vn).x = cx;
     ND_lw(vn) = cx - lx, ND_rw(vn) = rx - cx;
@@ -2501,9 +2499,7 @@ _neighbor(graph_t* g, node_t *vn, edge_t *ie, edge_t *oe, int dir)
     return rv;
 }
 
-static boolean pathscross(n0, n1, ie1, oe1)
-node_t *n0, *n1;
-edge_t *ie1, *oe1;
+static boolean pathscross(node_t * n0, node_t * n1, edge_t * ie1, edge_t * oe1)
 {
     edge_t *e0, *e1;
     node_t *na, *nb;


### PR DESCRIPTION
New versions of clang have a confusing error message about missing prototypes that is actually complaining about parameter style.
