### PR TITLE
Fix deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# go-graphviz [![Go](https://github.com/goccy/go-graphviz/workflows/Go/badge.svg)](https://github.com/goccy/go-graphviz/actions) [![GoDoc](https://godoc.org/github.com/goccy/go-graphviz?status.svg)](https://pkg.go.dev/github.com/goccy/go-graphviz) 
+# go-graphviz [![Go](https://github.com/goccy/go-graphviz/workflows/Go/badge.svg)](https://github.com/goccy/go-graphviz/actions) [![GoDoc](https://godoc.org/github.com/goccy/go-graphviz?status.svg)](https://pkg.go.dev/github.com/goccy/go-graphviz)
 
 Go bindings for Graphviz ( port of version `2.40.1` )
 
@@ -79,7 +79,7 @@ func main() {
 
 ```go
 path := "/path/to/dot.gv"
-b, err := ioutil.ReadFile(path)
+b, err := os.ReadFile(path)
 if err != nil {
   log.Fatal(err)
 }

--- a/cgraph/cgraph.go
+++ b/cgraph/cgraph.go
@@ -1,7 +1,7 @@
 package cgraph
 
 import (
-	"io/ioutil"
+	"os"
 	"unsafe"
 
 	"github.com/goccy/go-graphviz/cdt"
@@ -110,7 +110,7 @@ func ParseBytes(bytes []byte) (*Graph, error) {
 }
 
 func ParseFile(path string) (*Graph, error) {
-	file, err := ioutil.ReadFile(path)
+	file, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/dot/dot.go
+++ b/cmd/dot/dot.go
@@ -3,13 +3,13 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/goccy/go-graphviz"
 	"github.com/goccy/go-graphviz/cgraph"
 	"github.com/jessevdk/go-flags"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 type Option struct {
@@ -20,10 +20,10 @@ type Option struct {
 
 func readGraph(args []string) (*cgraph.Graph, error) {
 	if len(args) == 0 {
-		if terminal.IsTerminal(0) {
+		if term.IsTerminal(0) {
 			return nil, errors.New("required dot file or stdin")
 		}
-		bytes, err := ioutil.ReadAll(os.Stdin)
+		bytes, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return nil, err
 		}

--- a/compatible_test.go
+++ b/compatible_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"image"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -35,7 +34,7 @@ func generateTestData() error {
 			if info.IsDir() {
 				return nil
 			}
-			tmpfile, err := ioutil.TempFile("", "graphviz")
+			tmpfile, err := os.CreateTemp("", "graphviz")
 			if err != nil {
 				return err
 			}
@@ -65,7 +64,7 @@ func generateTestData() error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(imageHashJSON, content, 0644); err != nil {
+	if err := os.WriteFile(imageHashJSON, content, 0644); err != nil {
 		return err
 	}
 	return nil
@@ -77,7 +76,7 @@ func TestGraphviz_Compatible(t *testing.T) {
 	//		t.Fatal(err)
 	//	}
 	var pathToHashDump map[string]string
-	file, err := ioutil.ReadFile(imageHashJSON)
+	file, err := os.ReadFile(imageHashJSON)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +88,7 @@ func TestGraphviz_Compatible(t *testing.T) {
 			if info.IsDir() {
 				return nil
 			}
-			file, err := ioutil.ReadFile(path)
+			file, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,11 @@ require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/pkg/errors v0.9.1
-	golang.org/x/crypto v0.7.0
 	golang.org/x/image v0.14.0
+	golang.org/x/term v0.6.0
 )
 
 require (
 	github.com/nfnt/resize v0.0.0-20160724205520-891127d8d1b5 // indirect
 	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/term v0.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/nfnt/resize v0.0.0-20160724205520-891127d8d1b5 h1:BvoENQQU+fZ9uukda/R
 github.com/nfnt/resize v0.0.0-20160724205520-891127d8d1b5/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
-golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/image v0.14.0 h1:tNgSxAFe3jC4uYqvZdTr84SZoM1KfwdC9SKIFrLjFn4=
 golang.org/x/image v0.14.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=

--- a/graphviz_test.go
+++ b/graphviz_test.go
@@ -2,7 +2,6 @@ package graphviz_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -125,7 +124,7 @@ func TestParseFile(t *testing.T) {
 	}
 
 	createTempFile := func(t *testing.T, content string) *os.File {
-		file, err := ioutil.TempFile("", "*")
+		file, err := os.CreateTemp("", "*")
 		if err != nil {
 			t.Fatalf("There was an error creating a temporary file. Error: %+v", err)
 			return nil


### PR DESCRIPTION
Thanks for the great package! It helped me simplify 2 projects by rendering in Go instead of Javascript.

But I noticed there is still some deprecated code being used. This PR fixes:
- `ioutil` => Replaced by functions in the `io` and `os` packages
- `golang.org/x/crypto/ssh/terminal` => Replaced by `golang.org/x/term`

There is also `reflect.SliceHeader` in `internal/ccall/cdt.go` (replaced by `unsafe.Slice` and `unsafe.SliceData`), but I don't feel comfortable enough with the unsafe package to tackle those.