### PR TITLE
add cgraph setters for fontname

### DIFF
--- a/cgraph/attribute.go
+++ b/cgraph/attribute.go
@@ -740,6 +740,30 @@ func (e *Edge) SetFontColor(v string) *Edge {
 	return e
 }
 
+// SetFontName
+// Font used for text.
+// https://graphviz.gitlab.io/_pages/doc/info/attrs.html#a:fontname
+func (g *Graph) SetFontName(v string) *Graph {
+	g.SafeSet(string(fontNameAttr), v, "Times-Roman")
+	return g
+}
+
+// SetFontName
+// Font used for text.
+// https://graphviz.gitlab.io/_pages/doc/info/attrs.html#a:fontname
+func (n *Node) SetFontName(v string) *Node {
+	n.SafeSet(string(fontNameAttr), v, "Times-Roman")
+	return n
+}
+
+// SetFontName
+// Font used for text.
+// https://graphviz.gitlab.io/_pages/doc/info/attrs.html#a:fontname
+func (e *Edge) SetFontName(v string) *Edge {
+	e.SafeSet(string(fontNameAttr), v, "Times-Roman")
+	return e
+}
+
 // SetFontSize
 // Font size, in points, used for text.
 // https://graphviz.gitlab.io/_pages/doc/info/attrs.html#a:fontsize


### PR DESCRIPTION
Add support for setting `fontname` attribute from `cgraph`.

Related issue https://github.com/goccy/go-graphviz/issues/58