### PR TITLE
fix: Fix to add missing toDictWasm

### DIFF
--- a/cdt/cdt.go
+++ b/cdt/cdt.go
@@ -18,6 +18,10 @@ func toDict(v *wasm.Dict) *Dict {
 	return &Dict{wasm: v}
 }
 
+func toDictWasm(v *Dict) *wasm.Dict {
+	return v.wasm
+}
+
 func (d *Dict) getWasm() *wasm.Dict {
 	return d.wasm
 }


### PR DESCRIPTION
Thank you for the wonderful library. 
I tried to use it but encountered the following error, so I'm submitting a fix.

```
github.com/goccy/go-graphviz/cgraph.(*CommonFields).SetStrDict: relocation target github.com/goccy/go-graphviz/cdt.toDictWasm not defined
github.com/goccy/go-graphviz/cgraph.(*CommonFields).SetLookupByName: relocation target github.com/goccy/go-graphviz/cdt.toDictWasm not defined
github.com/goccy/go-graphviz/cgraph.(*CommonFields).SetLookupByID: relocation target github.com/goccy/go-graphviz/cdt.toDictWasm not defined
github.com/goccy/go-graphviz/cgraph.(*Graph).SetNSeq: relocation target github.com/goccy/go-graphviz/cdt.toDictWasm not defined
github.com/goccy/go-graphviz/cgraph.(*Graph).SetESeq: relocation target github.com/goccy/go-graphviz/cdt.toDictWasm not defined
github.com/goccy/go-graphviz/cgraph.(*Graph).SetEID: relocation target github.com/goccy/go-graphviz/cdt.toDictWasm not defined
github.com/goccy/go-graphviz/cgraph.(*Graph).SetGSeq: relocation target github.com/goccy/go-graphviz/cdt.toDictWasm not defined
github.com/goccy/go-graphviz/cgraph.(*Graph).SetGID: relocation target github.com/goccy/go-graphviz/cdt.toDictWasm not defined
```