### PR TITLE
pick up dropped test error

### DIFF
--- a/compatible_test.go
+++ b/compatible_test.go
@@ -32,6 +32,9 @@ func generateTestData() error {
 	pathToHashDump := map[string]string{}
 	for _, path := range testPaths {
 		if err := filepath.Walk(path, func(p string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
 			if info.IsDir() {
 				return nil
 			}


### PR DESCRIPTION
This picks up an `err` variable that was dropped in `compatible_test.go`. Unit tests passed before and after the change.